### PR TITLE
Allow header lines with double digit values

### DIFF
--- a/header.go
+++ b/header.go
@@ -12,8 +12,8 @@ import (
 )
 
 var typeRe = `String|Integer|Float|Flag|Character|Unknown`
-var infoRegexp = regexp.MustCompile(fmt.Sprintf(`##INFO=<ID=(.+),Number=([\dAGR\.]?),Type=(%s),Description="(.+)">`, typeRe))
-var formatRegexp = regexp.MustCompile(fmt.Sprintf(`##FORMAT=<ID=(.+),Number=([\dAGR\.]?),Type=(%s),Description="(.+)">`, typeRe))
+var infoRegexp = regexp.MustCompile(fmt.Sprintf(`##INFO=<ID=(.+),Number=([\dAGR\.]*),Type=(%s),Description="(.+)">`, typeRe))
+var formatRegexp = regexp.MustCompile(fmt.Sprintf(`##FORMAT=<ID=(.+),Number=([\dAGR\.]*),Type=(%s),Description="(.+)">`, typeRe))
 var filterRegexp = regexp.MustCompile(`##FILTER=<ID=(.+),Description="(.+)">`)
 var contigRegexp = regexp.MustCompile(`contig=<.*((\w+)=([^,>]+))`)
 var sampleRegexp = regexp.MustCompile(`SAMPLE=<ID=([^,>]+)`)

--- a/header_test.go
+++ b/header_test.go
@@ -21,12 +21,14 @@ var vcfStr = `##fileformat=VCFv4.2
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
 ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
 ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=LONG,Number=10,Type=Flag,Description="Large number of values">
 ##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
 ##FILTER=<ID=q10,Description="Quality below 10">
 ##FILTER=<ID=s50,Description="Less than 50% of samples have data">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=LONG,Number=10,Type=Integer,Description="Long number of values">
 ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
 20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.


### PR DESCRIPTION
Brent;
I ran into this issue while using vcfanno, and think this works around it with the tests passing. As an aside, do you have any tips/tricks to getting started developing with go. I'm cloning projects into `src/github.com/brentp/vcfgo` and then messing directly with them there but then not sure how best to manage a fork for testing purposes. I'm only cobbling together approaches from searching so would love a "how to do it" guide so I can help contribute patches instead of just bug reports. Thanks much.

Specifications with non-single digit values, like `Number=10` failed
since the regular expression checked for a single integer value.