### PR TITLE
Prevent ParseSamples errors from being hidden

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -239,11 +239,15 @@ func (h *Header) ParseSamples(v *Variant) error {
 		return nil
 	}
 	var errors []error
+	var errs []error
 	v.Samples = make([]*SampleGenotype, len(h.SampleNames))
 
 	for i, sample := range strings.Split(v.sampleString, "\t") {
 		var geno *SampleGenotype
-		geno, errors = h.parseSample(v.Format, sample)
+		geno, errs = h.parseSample(v.Format, sample)
+		if len(errs) > 0 {
+			errors = append(errors, errs...)
+		}
 
 		v.Samples[i] = geno
 	}


### PR DESCRIPTION
The `header.ParseSamples` method overwrites the errors slice with every new sample. So, if the very last sample has no errors, then `header.ParseSamples` reports that there was no error. 

This commit causes `header.ParseSamples` to accumulate all errors in sample parsing, permitting it to indicate if *any* sample was incorrectly parsed, rather than the current behavior which only tells you whether or not the last sample was incorrectly parsed.

(Note: This came to my attention while troubleshooting what I think is an issue with my `io.Reader` wrapper from #11 , which may be nulling out data as you had pointed out.)