### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -253,13 +253,13 @@ func (h *Header) ParseSamples(v *Variant) error {
 	return nil
 }
 
-// Add a INFO field to the header.
+// AddInfoToHeader adds a INFO field to the header.
 func (vr *Reader) AddInfoToHeader(id string, num string, stype string, desc string) {
 	h := vr.Header
 	h.Infos[id] = &Info{Id: id, Number: num, Type: stype, Description: desc}
 }
 
-// Add a FORMAT field to the header.
+// AddFormatToHeader adds a FORMAT field to the header.
 func (vr *Reader) AddFormatToHeader(id string, num string, stype string, desc string) {
 	h := vr.Header
 	h.SampleFormats[id] = &SampleFormat{Id: id, Number: num, Type: stype, Description: desc}

--- a/variant.go
+++ b/variant.go
@@ -223,7 +223,7 @@ type SampleGenotype struct {
 	Fields map[string]string
 }
 
-// RefDepths returns the depths of the alternates for this sample
+// RefDepth returns the depths of the alternates for this sample
 func (s *SampleGenotype) RefDepth() (int, error) {
 	if ad, ok := s.Fields["AD"]; ok {
 		idx := strings.Index(ad, ",")


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?