### PR TITLE
Remove check for a QUAL score of 256

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -37,6 +37,7 @@ import (
 
 // MISSING_VAL represents a signaling NaN for missing values
 const missingBits uint32 =  0x7F800001
+var MISSING_VAL = math.Float32frombits(missingBits)
 
 // Reader holds information about the current line number (for errors) and
 // The VCF header that indicates the structure of records.

--- a/reader.go
+++ b/reader.go
@@ -28,14 +28,15 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"strings"
 	"unsafe"
 )
 
-// used for the quality score which is 0 to 255, but allows "."
-const MISSING_VAL =  -1
+// MISSING_VAL represents a signaling NaN for missing values
+const missingBits uint32 =  0x7F800001
 
 // Reader holds information about the current line number (for errors) and
 // The VCF header that indicates the structure of records.

--- a/reader.go
+++ b/reader.go
@@ -35,7 +35,7 @@ import (
 )
 
 // used for the quality score which is 0 to 255, but allows "."
-const MISSING_VAL = 256
+const MISSING_VAL =  -1
 
 // Reader holds information about the current line number (for errors) and
 // The VCF header that indicates the structure of records.

--- a/variant.go
+++ b/variant.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 
@@ -288,7 +289,7 @@ func NewSampleGenotype() *SampleGenotype {
 func (v *Variant) String() string {
 	var qual string
 	
-	if v.Quality < 0 {
+	if math.Float32bits(v.Quality) == missingBits {
 		qual = "."
 	} else {
 		qual = fmt.Sprintf("%.1f", v.Quality)

--- a/variant.go
+++ b/variant.go
@@ -287,8 +287,12 @@ func NewSampleGenotype() *SampleGenotype {
 // String gives a string representation of a variant
 func (v *Variant) String() string {
 	var qual string
-
-	qual = fmt.Sprintf("%.1f", v.Quality)
+	
+	if v.Quality < 0 {
+		qual = "."
+	} else {
+		qual = fmt.Sprintf("%.1f", v.Quality)
+	}
 
 	s := fmt.Sprintf("%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s", v.Chromosome, v.Pos, v.Id_, v.Ref(), strings.Join(v.Alt(), ","), qual, v.Filter, v.Info())
 	if len(v.Samples) > 0 {

--- a/variant.go
+++ b/variant.go
@@ -287,11 +287,9 @@ func NewSampleGenotype() *SampleGenotype {
 // String gives a string representation of a variant
 func (v *Variant) String() string {
 	var qual string
-	if v.Quality == MISSING_VAL {
-		qual = "."
-	} else {
-		qual = fmt.Sprintf("%.1f", v.Quality)
-	}
+
+	qual = fmt.Sprintf("%.1f", v.Quality)
+
 	s := fmt.Sprintf("%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s", v.Chromosome, v.Pos, v.Id_, v.Ref(), strings.Join(v.Alt(), ","), qual, v.Filter, v.Info())
 	if len(v.Samples) > 0 {
 		samps := make([]string, len(v.Samples))


### PR DESCRIPTION
Dear Brent, for multiple variant callers (like GATK Haplotypecaller, VarDict or Manta) a QUAL score of 256 is not a fixed value or placeholder when Phred-scaled quality score cannot be calculated. This proposed fix should solve https://github.com/brentp/vcfanno/issues/161.  Thank you for looking at this. All the best